### PR TITLE
Fix mobile responsiveness for Meet the team page

### DIFF
--- a/sections/media-inline-text.liquid
+++ b/sections/media-inline-text.liquid
@@ -77,9 +77,6 @@
       margin-left: 30px;
       margin-bottom: 20px;
     }
-
-    .inline-media-thumbnail {
-    }
   }
 </style>
 

--- a/sections/media-inline-text.liquid
+++ b/sections/media-inline-text.liquid
@@ -8,7 +8,6 @@
     font-size: 32px;
     margin-top: 40px;
     margin-bottom: 40px;
-    font-weight: bold;
   }
 
   .overflow-text {
@@ -43,8 +42,8 @@
     left: 50%;
     transform: translate(-50%, -50%);
     background: rgba(255, 255, 255, 0.7);
-    width: 150px;
-    height: 150px;
+    width: 30%;
+    height: 50%;
     border-radius: 50%;
     display: flex;
     justify-content: center;
@@ -57,6 +56,30 @@
     border-left: 40px solid rgba(0, 0, 0, 0.5);
     border-top: 24px solid transparent;
     border-bottom: 24px solid transparent;
+  }
+
+  @media screen and (max-width: 767px) {
+    .overlay-button {
+      border-left: 20px solid rgba(0, 0, 0, 0.5);
+      border-top: 12px solid transparent;
+      border-bottom: 12px solid transparent;
+    }
+  }
+
+  @media screen and (max-width: 540px) {
+    .inline-media-heading {
+      text-align: left;
+    }
+
+    .media-float {
+      width: 100%;
+      margin-top: 20px;
+      margin-left: 30px;
+      margin-bottom: 20px;
+    }
+
+    .inline-media-thumbnail {
+    }
   }
 </style>
 

--- a/sections/meet-the-team-section.liquid
+++ b/sections/meet-the-team-section.liquid
@@ -14,7 +14,6 @@
     font-size: 32px;
     margin-top: 40px;
     margin-bottom: 40px;
-    font-weight: bold;
   }
 
   .profile-card {
@@ -80,8 +79,16 @@
     color: #333;
     alignment: justify;
   }
+
+  @media screen and (max-width: 540px) {
+    .team-heading {
+      text-align: left;
+      margin-left: 30px;
+    }
+  }
 </style>
 
+<h2 class="team-heading">{{ section.settings.meet_the_team_title }}</h2>
 <div class="team-container">
   {% for block in section.blocks %}
     <div class="profile-card col-md-6">
@@ -117,7 +124,14 @@
 {% schema %}
 {
   "name": "Meet the team section",
-  "settings": [],
+  "settings": [
+    {
+      "type": "text",
+      "id": "meet_the_team_title",
+      "label": "Meet the team title",
+      "default": "Meet the team"
+    }
+  ],
   "blocks": [
     {
       "type": "card-person-profile",

--- a/sections/multi-column-logos.liquid
+++ b/sections/multi-column-logos.liquid
@@ -7,7 +7,6 @@
     text-align: center;
     font-size: 32px;
     margin: 40px auto;
-    font-weight: bold;
   }
 
   .cards-container {
@@ -38,6 +37,40 @@
     color: #333;
     text-align: center;
   }
+
+  @media screen and (max-width: 540px) {
+    .awards-heading {
+      font-size: 30px;
+      margin-bottom: 10px;
+    }
+
+    .awards-heading {
+      text-align: left;
+    }
+
+    .award-card {
+      flex-direction: row;
+      margin: 5px 0;
+    }
+
+    .award-photo {
+      width: 30%;
+      height: 100%;
+      object-fit: contain;
+    }
+
+    .award-description {
+      display: flex;
+      text-align: left;
+      height: 100%;
+      margin: 0 0 0 15px;
+      font-size: 14px;
+      line-height: 1.6;
+      font-weight: bold;
+      color: #333;
+      align-items: center;
+    }
+  }
 </style>
 
 <section class="awards-section">
@@ -58,6 +91,27 @@
     {% endfor %}
   </div>
 </section>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    function removeIntentionalBreaksOnSmallScreens() {
+      const elements = document.getElementsByClassName('award-description');
+
+      if (window.innerWidth <= 540) {
+        Array.from(elements).forEach((el) => {
+          const brs = el.querySelectorAll('br');
+          brs.forEach((br) => br.remove());
+        });
+      }
+    }
+
+    // Run on initial load
+    removeIntentionalBreaksOnSmallScreens();
+
+    // Run again on resize
+    window.addEventListener('resize', removeIntentionalBreaksOnSmallScreens);
+  });
+</script>
 
 {% schema %}
 {


### PR DESCRIPTION
While updating develop branch content, noticed issue with mobile responsiveness of text inline media and awards descriptions. Fixed by setting values for smaller `@media screen`

Additional changes:
- fix missing page title `Meet the team`
- Included script to handle removal of intentional line breaks `<br>` on small screens for award descriptions
    - Note: Intentional breaks `<br>` are used instead of placing content in separate text blocks just to accommodate the requirement