### PR TITLE
Add spacer/offset for navigation to section

### DIFF
--- a/sections/media-inline-text.liquid
+++ b/sections/media-inline-text.liquid
@@ -116,8 +116,9 @@
   }
 </style>
 
+<div style="height: 80px; margin-top: -80px;" id="{{ section.settings.page_section_id }}"></div>
 <section class="inline-media-section">
-  <h2 class="inline-media-heading" id="{{ section.settings.page_section_id }}">{{ section.settings.title }}</h2>
+  <h2 class="inline-media-heading">{{ section.settings.title }}</h2>
 
   {% for block in section.blocks %}
     {% if block.settings.is_above_media %}
@@ -152,6 +153,19 @@
     {% endfor %}
   </div>
 </section>
+
+{% comment %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      console.log('Triggered!');
+      const scrollFocusElement = document.getElementById('{{ section.settings.page_section_id }}');
+      if (scrollFocusElement) {
+        console.log('Pasok!');
+        scrollFocusElement.style.scrollMarginTop = '1000px'; // Set offset
+      }
+    });
+  </script>
+{% endcomment %}
 
 {% schema %}
 {

--- a/sections/media-inline-text.liquid
+++ b/sections/media-inline-text.liquid
@@ -154,19 +154,6 @@
   </div>
 </section>
 
-{% comment %}
-  <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      console.log('Triggered!');
-      const scrollFocusElement = document.getElementById('{{ section.settings.page_section_id }}');
-      if (scrollFocusElement) {
-        console.log('Pasok!');
-        scrollFocusElement.style.scrollMarginTop = '1000px'; // Set offset
-      }
-    });
-  </script>
-{% endcomment %}
-
 {% schema %}
 {
   "name": "Media inline text",

--- a/sections/multi-column-logos.liquid
+++ b/sections/multi-column-logos.liquid
@@ -76,7 +76,8 @@
   }
 </style>
 
-<section class="awards-section" id="{{ section.settings.page_section_id }}">
+<div style="height: 80px; margin-top: -80px;" id="{{ section.settings.page_section_id }}"></div>
+<section class="awards-section">
   <h2 class="awards-heading">{{ section.settings.multi_column_awards_title }}</h2>
 
   <div class="cards-container">


### PR DESCRIPTION
Changes:
- Adds a spacer element to provide offset when navigation is pointed to an anchor section

Note: Looks like the issue is with the header always rendered on top. When navigating to a section, the view begins from the very top, causing the title to be hidden behind the header.